### PR TITLE
add per_decade binning for VERITAS analysis

### DIFF
--- a/vtspy/analysis/veritas_analysis.py
+++ b/vtspy/analysis/veritas_analysis.py
@@ -72,10 +72,12 @@ class VeritasAnalysis:
         self._bias_cut = self.config['cuts']['bias_cut']
         self._max_region_number = self.config['selection']['max_region_number']
 
-        self._energy_bins = MapAxis.from_bounds(self.config["selection"]["emin"],
+        self._energy_bins = MapAxis.from_energy_bounds(
+            self.config["selection"]["emin"], 
             self.config["selection"]["emax"],
             nbin=self.config["selection"]["nbin"],
-            interp="log", unit="TeV").edges
+            per_decade=self.config["selection"]["per_decade"],
+            unit="TeV").edges
         self._energy_axis = MapAxis.from_energy_bounds(
             1e-2, 1e4, nbin=10, per_decade=True, unit="TeV", name="energy"
         )

--- a/vtspy/config.py
+++ b/vtspy/config.py
@@ -504,6 +504,7 @@ class JointConfig:
 				'emin': 0.1,
 				'emax': 10,
 				'nbin': 6,
+				'per_decade': True,
 				'format': "mjd",
 				'max_region_number': 6,
 				'radius': 2.0,


### PR DESCRIPTION
Currently can only specify the total number of bins for VERITAS analysis. Added functionality (and config variable) to specify as a boolean whether you want those number of bins to be per_decade or not.