### PR TITLE
Fix for default fermi binning to use binsperdecade unless nbins specified

### DIFF
--- a/vtspy/analysis/fermi_analysis.py
+++ b/vtspy/analysis/fermi_analysis.py
@@ -572,7 +572,9 @@ class FermiAnalysis():
                 name="energy",
                 interp="log", unit="MeV")
 
-        loge_bins = kwargs.pop("loge_bins",  np.log10(self._energy_bins.edges.value))
+            loge_bins = kwargs.pop("loge_bins",  np.log10(self._energy_bins.edges.value))
+        else:
+            loge_bins = self.gta.log_energies
 
         o = self.gta.sed(self.target.name, outfile=outfile, bin_index=kwargs.pop("bin_index", 2.0), loge_bins=loge_bins, write_fits=True, write_npy=True, **kwargs)
         self._logging.info("Generating the SED is completed.")

--- a/vtspy/analysis/veritas_analysis.py
+++ b/vtspy/analysis/veritas_analysis.py
@@ -58,7 +58,7 @@ class VeritasAnalysis:
             **kwargs: passed to VeritasAnalysis.setup
         """
         self._verbosity = verbosity
-
+        
         self.config = JointConfig.get_config(config_file).pop("veritas")
 
         self._logging = logger(self.verbosity)


### PR DESCRIPTION
Title says it all, a fix for #7.